### PR TITLE
Fix pluralization in search feedback

### DIFF
--- a/hooks/useFoodSearch.ts
+++ b/hooks/useFoodSearch.ts
@@ -81,9 +81,10 @@ export const useFoodSearch = (databaseId: string) => {
       }
 
       const totalFoods = allFoods.reduce((sum, result) => sum + result.foods.length, 0);
+      const queryLabel = activeQueries.length === 1 ? 'query' : 'queries';
       setFeedbackMessage({
         type: 'info',
-        message: `Found ${totalFoods} food item(s) for ${activeQueries.length} quer(y/ies).`
+        message: `Found ${totalFoods} food item(s) for ${activeQueries.length} ${queryLabel}.`
       });
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- improve text for search results feedback with singular/plural

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca8e79b60832887d7869afd00ee5c