### PR TITLE
Fix zero nutrient handling

### DIFF
--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -113,7 +113,7 @@ export const mapFoodCategory = (usdaCategory: any) => {
   
   // Helper function to format nutrient value with proper rounding and color coding for Notion
   const formatNutrientForNotion = (value: number | undefined | null, unit = '') => {
-    if (value === undefined || value === null || value === 0) {
+    if (value === undefined || value === null) {
       return {
         text: 'N/A',
         color: 'red'


### PR DESCRIPTION
## Summary
- treat zero nutrient values as valid in Notion formatting

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca8f067ac8328a5d15e616e723ad3