### PR TITLE
Rename propertyCount to pageCount

### DIFF
--- a/app/api/notion/database/[databaseId]/route.ts
+++ b/app/api/notion/database/[databaseId]/route.ts
@@ -17,7 +17,7 @@ export async function GET(
         database_id: databaseId,
       });
   
-      // Get the first 100 pages to count total entries
+      // Get the first 100 pages to count total pages
       const pages = await notion.databases.query({
         database_id: databaseId,
         page_size: 100,
@@ -25,7 +25,7 @@ export async function GET(
   
       const response = {
         title: (database as any).title[0]?.plain_text || "Untitled",
-        propertyCount: pages.results.length,
+        pageCount: pages.results.length,
         properties: Object.entries(database.properties).map(([name, prop]) => ({
           name,
           type: prop.type,

--- a/components/NotionSettings.tsx
+++ b/components/NotionSettings.tsx
@@ -81,7 +81,7 @@ export const NotionSettings: React.FC<NotionSettingsProps> = ({
             <div>
             <h4 className="font-medium text-gray-900">Database Info</h4>
             <p className="text-sm text-gray-600">Name: {dbInfo.title}</p>
-            <p className="text-sm text-gray-600">Total Pages: {dbInfo.propertyCount}</p>
+            <p className="text-sm text-gray-600">Total Pages: {dbInfo.pageCount}</p>
             </div>
             
             <div>

--- a/types/index.ts
+++ b/types/index.ts
@@ -171,7 +171,7 @@ export interface NotionCreationResponse {
 
 export interface NotionDatabaseInfo {
   title: string;
-  propertyCount: number;
+  pageCount: number;
   properties: Array<{
     name: string;
     type: string;


### PR DESCRIPTION
## Summary
- rename propertyCount field to pageCount across the codebase
- adjust Notion route response and settings UI to display page count

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca8f9b4c48328904fc89d8b30892d