### PR TITLE
Handle new Notion fields and Foundational serving size

### DIFF
--- a/app/api/notion/pages/route.ts
+++ b/app/api/notion/pages/route.ts
@@ -40,6 +40,12 @@ export async function POST(request: Request) {
             text: { content: servingSize }
           }]
         },
+        "Data Type": {
+          select: { name: food.dataType || 'Foundational' }
+        },
+        "Brand Name": {
+          rich_text: food.brandName ? [{ text: { content: food.brandName } }] : []
+        },
         "FDC ID": {
           number: food.id || 0
         },

--- a/services/usdaApi.ts
+++ b/services/usdaApi.ts
@@ -121,16 +121,20 @@ export const processFoodDetails = (foodDetails: FoodDetailsResponse): ProcessedF
     }
   }
 
+  const isFoundational =
+    foodDetails.dataType && foodDetails.dataType.toLowerCase().includes('foundation');
+
   // Initialize the processed food item
   const processed: ProcessedFoodItem = {
     id: foodDetails.fdcId,
     description: foodDetails.description,
     brandOwner: foodDetails.brandOwner,
     brandName: foodDetails.brandName,
+    dataType: isFoundational ? 'Foundational' : 'Branded',
     foodCategory,
     ingredients: foodDetails.ingredients,
-    servingSize: foodDetails.servingSize,
-    servingSizeUnit: foodDetails.servingSizeUnit,
+    servingSize: foodDetails.servingSize ?? (isFoundational ? 100 : undefined),
+    servingSizeUnit: foodDetails.servingSizeUnit ?? (isFoundational ? 'g' : undefined),
     nutrients: {
       calories,
       energyKj: findNutrientValue(nutrients, NUTRIENT_IDS.ENERGY_KJ),

--- a/types/index.ts
+++ b/types/index.ts
@@ -100,6 +100,7 @@ export interface ProcessedFoodItem {
   description: string;
   brandOwner?: string;
   brandName?: string;
+  dataType?: DataType;
   foodCategory?: string;
   ingredients?: string;
   servingSize?: number;
@@ -184,7 +185,7 @@ export interface FeedbackMessage {
   details?: string;
 }
 
-export type DataType = 'Foundation' | 'Branded';
+export type DataType = 'Foundational' | 'Branded';
 
 export interface DataTypeFilter {
   foundation: boolean;


### PR DESCRIPTION
## Summary
- keep track of each item's data type when processing USDA details
- default serving size to `100 g` for foundational data
- send `Data Type` and `Brand Name` when creating Notion pages
- update types

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_684cc99871c48328b9030a83aba45c95