### PR TITLE
Display Notion pages for existing foods

### DIFF
--- a/app/api/notion/database/[databaseId]/map/route.ts
+++ b/app/api/notion/database/[databaseId]/map/route.ts
@@ -1,0 +1,50 @@
+import { Client } from '@notionhq/client';
+import { NextResponse } from 'next/server';
+
+const notion = new Client({
+  auth: process.env.NOTION_API_KEY,
+});
+
+export async function GET(
+  request: Request,
+  { params }: { params: { databaseId: string } }
+) {
+  try {
+    const { databaseId } = params;
+    let hasMore = true;
+    let startCursor: string | undefined = undefined;
+    const map: Record<number, string> = {};
+
+    while (hasMore) {
+      const response: any = await notion.databases.query({
+        database_id: databaseId,
+        page_size: 100,
+        start_cursor: startCursor,
+        filter: {
+          property: 'FDC ID',
+          number: {
+            is_not_empty: true,
+          },
+        },
+      });
+
+      response.results.forEach((page: any) => {
+        const id = page.properties['FDC ID']?.number;
+        if (id) {
+          map[id] = page.id;
+        }
+      });
+
+      hasMore = response.has_more;
+      startCursor = response.next_cursor;
+    }
+
+    return NextResponse.json({ map });
+  } catch (error: any) {
+    console.error('Error fetching FDC map from Notion:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to fetch FDC map from Notion' },
+      { status: error.status || 500 }
+    );
+  }
+}

--- a/app/api/notion/pages/[pageId]/route.ts
+++ b/app/api/notion/pages/[pageId]/route.ts
@@ -5,6 +5,28 @@ const notion = new Client({
   auth: process.env.NOTION_API_KEY,
 });
 
+export async function GET(
+  request: Request,
+  { params }: { params: { pageId: string } }
+) {
+  try {
+    const { pageId } = params;
+    const page = await notion.pages.retrieve({ page_id: pageId });
+    const blocks = await notion.blocks.children.list({
+      block_id: pageId,
+      page_size: 100,
+    });
+
+    return NextResponse.json({ page, blocks: blocks.results });
+  } catch (error: any) {
+    console.error('Error fetching Notion page:', error);
+    return NextResponse.json(
+      { error: error.message || 'Failed to fetch Notion page' },
+      { status: error.status || 500 }
+    );
+  }
+}
+
 export async function PATCH(request: Request, { params }: { params: { pageId: string } }) {
   try {
     const { pageId } = params;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,6 @@ import { getNotionDatabaseInfo } from '@/services/notionApi';
 import { NotionCreationResponse } from '@/types';
 
 export default function Home() {
-  const [pageIds, setPageIds] = useState<Record<number, string>>({});
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [searchModalOpen, setSearchModalOpen] = useState(false);
   const [notionModalOpen, setNotionModalOpen] = useState(false);
@@ -41,6 +40,8 @@ export default function Home() {
     updateQuery,
     updateDataTypeFilter,
     addExistingFdcId,
+    addPageId,
+    pageIdMap,
     searchAllFoods,
     setFeedbackMessage
   } = useFoodSearch(notionDatabaseId);
@@ -91,7 +92,7 @@ export default function Home() {
     if (result.success) {
       addExistingFdcId(food.id);
       if (result.pageId) {
-        setPageIds(prev => ({ ...prev, [food.id]: result.pageId! }));
+        addPageId(food.id, result.pageId);
       }
     }
   };
@@ -225,7 +226,7 @@ export default function Home() {
                               isSaving={savingItems[food.fdcId] || false}
                               onSaveToNotion={handleSaveFood}
                               isAlreadyInNotion={existingFdcIds.has(food.fdcId)}
-                              notionPageId={pageIds[food.fdcId]}
+                              notionPageId={pageIdMap[food.fdcId]}
                               updatePage={updatePage}
                             />
                           ))}

--- a/hooks/useNotionPage.ts
+++ b/hooks/useNotionPage.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getNotionPage } from '@/services/notionApi';
+
+export const useNotionPage = (pageId?: string) => {
+  return useQuery({
+    queryKey: ['notionPage', pageId],
+    queryFn: () => getNotionPage(pageId!),
+    enabled: !!pageId,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+};

--- a/services/notionApi.ts
+++ b/services/notionApi.ts
@@ -78,4 +78,28 @@ export const getExistingFdcIds = async (databaseId: string): Promise<number[]> =
       // Return an empty array on error so the app can continue to function
       return [];
     }
-}; 
+};
+
+export const getFdcIdPageMap = async (
+  databaseId: string
+): Promise<Record<number, string>> => {
+  try {
+    const response = await axios.get(
+      `${API_BASE_URL}/notion/database/${databaseId}/map`
+    );
+    return response.data.map || {};
+  } catch (error) {
+    console.error('Error fetching FDC ID map:', error);
+    return {};
+  }
+};
+
+export const getNotionPage = async (pageId: string) => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/notion/pages/${pageId}`);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching Notion page:', error);
+    throw error;
+  }
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -201,4 +201,8 @@ export type DataType = 'Foundational' | 'Branded';
 export interface DataTypeFilter {
   foundation: boolean;
   branded: boolean;
-} 
+}
+
+export interface FdcIdPageMap {
+  [fdcId: number]: string;
+}


### PR DESCRIPTION
## Summary
- get FDC id to page id map from Notion
- expose GET `/api/notion/pages/[pageId]`
- add hook `useNotionPage`
- track page mapping in `useFoodSearch`
- render Notion data in `FoodCard`
- update home page to use new mapping
- add `FdcIdPageMap` type

## Testing
- `npx jest` *(fails: 403 Forbidden)*
- `npx tsc -p tsconfig.json --noEmit` *(errors: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6851e98a5cac8328a8566c0849e2611a